### PR TITLE
feat: Add support for aarch64 architecture in release workflow and in…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,10 @@ jobs:
             target: x86_64-unknown-linux-gnu
             binary_name: dotstate
             asset_name: dotstate-x86_64-unknown-linux-gnu
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            binary_name: dotstate
+            asset_name: dotstate-aarch64-unknown-linux-gnu
           - os: macos-latest
             target: x86_64-apple-darwin
             binary_name: dotstate

--- a/website/install.sh
+++ b/website/install.sh
@@ -89,7 +89,11 @@ download_binary() {
     # Determine asset name based on OS and architecture
     # Standard Rust target triple naming (matches GitHub release assets)
     if [ "$OS" = "linux" ]; then
-        ASSET_NAME="dotstate-x86_64-unknown-linux-gnu.tar.gz"
+        if [ "$ARCH" = "arm64" ]; then
+            ASSET_NAME="dotstate-aarch64-unknown-linux-gnu.tar.gz"
+        else
+            ASSET_NAME="dotstate-x86_64-unknown-linux-gnu.tar.gz"
+        fi
     elif [ "$OS" = "macos" ]; then
         if [ "$ARCH" = "arm64" ]; then
             ASSET_NAME="dotstate-aarch64-apple-darwin.tar.gz"


### PR DESCRIPTION
…stallation script

- Updated GitHub Actions workflow to include aarch64-unknown-linux-gnu target for the dotstate binary.
- Modified installation script to handle asset naming for aarch64 architecture on Linux, ensuring correct binary downloads based on the system architecture.

## Description
Brief description of what this PR does.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring

## Testing
- [ ] I have tested this locally
- [ ] I have added tests for new functionality
- [ ] All existing tests pass

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Related Issues
Closes #12

## Screenshots (if applicable)
Add screenshots to help explain your changes.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds ARM64 Linux support across release and install flows.
> 
> - Extend `release.yml` matrix with `aarch64-unknown-linux-gnu` target and assets
> - Update `website/install.sh` to select `dotstate-aarch64-unknown-linux-gnu.tar.gz` for Linux `arm64`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff6efb75e429518c47cf060275b0c4811478d187. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->