### PR TITLE
feat: Make existence check optional for custom packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enhanced package checking UX (removed auto-check on page load)
 - Better error messages and user feedback
 - Commit messages are now automatically generated from changed files instead of generic "Update dotfiles"
+- Made existence check field optional for custom packages (if empty, uses standard binary name check)
 
 ## [0.1.0] - 2025-01-XX
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -6545,13 +6545,10 @@ impl App {
 
         // Validate based on package type
         if is_custom {
-            // Custom packages require install_command and existence_check
+            // Custom packages require install_command
+            // existence_check is optional - if empty, we use binary name check
             if install_command.trim().is_empty() {
                 warn!("Package validation failed: install_command is empty for custom package");
-                return Ok(false);
-            }
-            if existence_check.trim().is_empty() {
-                warn!("Package validation failed: existence_check is empty for custom package");
                 return Ok(false);
             }
         } else {
@@ -6586,7 +6583,12 @@ impl App {
                 None
             },
             existence_check: if is_custom {
-                Some(existence_check.trim().to_string())
+                let trimmed = existence_check.trim();
+                if trimmed.is_empty() {
+                    None
+                } else {
+                    Some(trimmed.to_string())
+                }
             } else {
                 None
             },

--- a/src/components/package_manager.rs
+++ b/src/components/package_manager.rs
@@ -408,8 +408,8 @@ impl PackageManagerComponent {
                 &state.add_existence_check_input,
                 state.add_existence_check_cursor,
                 state.add_focused_field == AddPackageField::ExistenceCheck,
-                "Existence Check",
-                Some("Command to check if package exists"),
+                "Existence Check (optional)",
+                Some("Command to check if package exists (if empty, uses binary name check)"),
                 Alignment::Left,
                 false,
             )?;

--- a/src/utils/profile_manifest.rs
+++ b/src/utils/profile_manifest.rs
@@ -40,7 +40,9 @@ pub struct Package {
     /// Install command (only for custom packages, derived for managed packages)
     #[serde(default)]
     pub install_command: Option<String>,
-    /// Command to check if package exists (only for custom packages, derived for managed packages)
+    /// Command to check if package exists (optional for custom packages, derived for managed packages)
+    /// If None or empty for custom packages, the system will perform a standard existence check
+    /// derived from the binary name (checking if binary exists in PATH)
     #[serde(default)]
     pub existence_check: Option<String>,
     /// Optional manager-native check command (fallback when binary_name check fails)


### PR DESCRIPTION
- Updated the package validation logic to allow the existence check field to be optional for custom packages. If left empty, the system will perform a standard existence check based on the binary name.
- Enhanced documentation and user interface to reflect this change, indicating that the existence check is optional and providing clearer guidance on its usage.

## Description
Brief description of what this PR does.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring

## Testing
- [ ] I have tested this locally
- [ ] I have added tests for new functionality
- [ ] All existing tests pass

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Related Issues
Closes #16

## Screenshots (if applicable)
Add screenshots to help explain your changes.

